### PR TITLE
This resolves is UD-340 Contents of citation not generated correctly …

### DIFF
--- a/ndexutil/tsv/streamtsvloader.py
+++ b/ndexutil/tsv/streamtsvloader.py
@@ -397,8 +397,13 @@ class StreamTSVLoader (object):
                             'attribute_name': column_raw_temp
                         }
 
-                if not column_raw.get('data_type'):   # set the default datatype to string
-                    column_raw['data_type'] = 'string'
+                if not column_raw.get('data_type'):
+                    if column_raw.get('delimiter'):
+                        # if there is a delimiter, set the default datatype to list of strings
+                        column_raw['data_type'] = 'list_of_string'
+                    else:
+                        # set the default datatype to string
+                        column_raw['data_type'] = 'string'
 
                 if not column_raw.get('attribute_name'):  # set the attribute name if it is not defined.
                     column_raw['attribute_name'] = column_raw.get('column_name')


### PR DESCRIPTION
…in CX by StreamTSVLoader.

Our general rule if there is no type specified in a load plan, we treat value as (default to) String.
I thinkk we need to check for delimiter and augment the rule to the following:
if there is no type specified then:
- default to String if there is no delimiter
- if there is a delijmiter, then default to List of Strings,